### PR TITLE
feat: 달력 관련 api 개발

### DIFF
--- a/src/main/java/com/example/thedayoftoday/app/CalendarController.java
+++ b/src/main/java/com/example/thedayoftoday/app/CalendarController.java
@@ -1,0 +1,35 @@
+package com.example.thedayoftoday.app;
+
+import com.example.thedayoftoday.domain.CalendarService;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/calendar")
+public class CalendarController {
+    private final CalendarService calendarService;
+
+    public CalendarController(CalendarService calendarService) {
+        this.calendarService = calendarService;
+    }
+
+    @GetMapping("/colors/{userId}/{year}/{month}")
+    public Map<String, Object> getMonthColors(@PathVariable Long userId, @PathVariable int year, @PathVariable int month) {
+        LocalDateTime startDate = LocalDateTime.of(year, month, 1, 0, 0);
+        LocalDateTime endDate = startDate.plusMonths(1).minusSeconds(1);
+        return calendarService.getMonthColors(userId, startDate, endDate);
+    }
+
+    @GetMapping("/diary/{userId}/{year}/{month}/{day}")
+    public Map<String, Object> getDiaryEntry(@PathVariable Long userId, @PathVariable int year, @PathVariable int month, @PathVariable int day) {
+        LocalDateTime date = LocalDateTime.of(year, month, day, 0, 0);
+        return calendarService.getDiaryEntry(userId, date);
+    }
+
+    @GetMapping("/analysis/{diaryId}")
+    public Map<String, Object> getSentimentalAnalysis(@PathVariable Long diaryId) {
+        return calendarService.getSentimentalAnalysis(diaryId);
+    }
+}

--- a/src/main/java/com/example/thedayoftoday/app/CalendarController.java
+++ b/src/main/java/com/example/thedayoftoday/app/CalendarController.java
@@ -15,21 +15,30 @@ public class CalendarController {
         this.calendarService = calendarService;
     }
 
-    @GetMapping("/colors/{userId}/{year}/{month}")
-    public Map<String, Object> getMonthColors(@PathVariable Long userId, @PathVariable int year, @PathVariable int month) {
+    @GetMapping("/{userId}/{year}/{month}")
+    public Map<String, Object> getMonthColors(@PathVariable Long userId,
+                                              @PathVariable int year,
+                                              @PathVariable int month) {
         LocalDateTime startDate = LocalDateTime.of(year, month, 1, 0, 0);
         LocalDateTime endDate = startDate.plusMonths(1).minusSeconds(1);
         return calendarService.getMonthColors(userId, startDate, endDate);
     }
 
     @GetMapping("/diary/{userId}/{year}/{month}/{day}")
-    public Map<String, Object> getDiaryEntry(@PathVariable Long userId, @PathVariable int year, @PathVariable int month, @PathVariable int day) {
+    public Map<String, Object> getDiaryEntry(@PathVariable Long userId,
+                                             @PathVariable int year,
+                                             @PathVariable int month,
+                                             @PathVariable int day) {
         LocalDateTime date = LocalDateTime.of(year, month, day, 0, 0);
         return calendarService.getDiaryEntry(userId, date);
     }
 
-    @GetMapping("/analysis/{diaryId}")
-    public Map<String, Object> getSentimentalAnalysis(@PathVariable Long diaryId) {
-        return calendarService.getSentimentalAnalysis(diaryId);
+    @GetMapping("/analysis/{userId}/{year}/{month}/{day}")
+    public Map<String, Object> getSentimentalAnalysis(@PathVariable Long userId,
+                                                      @PathVariable int year,
+                                                      @PathVariable int month,
+                                                      @PathVariable int day) {
+        LocalDateTime date = LocalDateTime.of(year, month, day, 0, 0);
+        return calendarService.getSentimentalAnalysis(userId, date);
     }
 }

--- a/src/main/java/com/example/thedayoftoday/domain/CalendarService.java
+++ b/src/main/java/com/example/thedayoftoday/domain/CalendarService.java
@@ -1,0 +1,84 @@
+package com.example.thedayoftoday.domain;
+
+import com.example.thedayoftoday.domain.entity.Diary;
+import com.example.thedayoftoday.domain.entity.SentimentalAnalysis;
+import com.example.thedayoftoday.domain.repository.DiaryRepository;
+import com.example.thedayoftoday.domain.repository.SentimentalAnalysisRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+
+@Service
+public class CalendarService {
+    private final DiaryRepository diaryRepository;
+    private final SentimentalAnalysisRepository sentimentalAnalysisRepository;
+
+    public CalendarService(DiaryRepository diaryRepository, SentimentalAnalysisRepository sentimentalAnalysisRepository) {
+        this.diaryRepository = diaryRepository;
+        this.sentimentalAnalysisRepository = sentimentalAnalysisRepository;
+    }
+
+    public Map<String, Object> getMonthColors(Long userId, LocalDateTime startDate, LocalDateTime endDate) {
+        List<Diary> diaries = diaryRepository.findByUser_UserIdAndCreateTimeBetween(userId, startDate, endDate);
+        Map<String, Object> response = new HashMap<>();
+
+        Map<String, String> colors = new HashMap<>();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+        for (Diary diary : diaries) {
+            String dateKey = diary.getCreateTime().format(formatter);
+            colors.put(dateKey, diary.getSentimentAnalysis() != null ? diary.getSentimentAnalysis().getMoodName() : "미분석");
+        }
+
+        response.put("userId", userId);
+        response.put("colors", colors);
+        return response;
+    }
+
+    public Map<String, Object> getDiaryEntry(Long userId, LocalDateTime date) {
+        List<Diary> diaries = diaryRepository.findByUser_UserIdAndCreateTimeBetween(
+                userId,
+                date.withHour(0).withMinute(0).withSecond(0),
+                date.withHour(23).withMinute(59).withSecond(59)
+        );
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("userId", userId);
+        response.put("date", date.toLocalDate().toString());
+
+        if (!diaries.isEmpty()) {
+            List<Map<String, Object>> diaryEntries = new ArrayList<>();
+            for (Diary diary : diaries) {
+                Map<String, Object> diaryData = new HashMap<>();
+                diaryData.put("title", diary.getTitle());
+                diaryData.put("content", diary.getContent());
+                diaryEntries.add(diaryData);
+            }
+            response.put("entries", diaryEntries);
+        } else {
+            response.put("entries", "일기가 없습니다.");
+        }
+
+        return response;
+    }
+
+    public Map<String, Object> getSentimentalAnalysis(Long diaryId) {
+        Optional<SentimentalAnalysis> analysisOptional = diaryRepository.findSentimentAnalysisByDiaryId(diaryId);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("diaryId", diaryId);
+
+        if (analysisOptional.isPresent()) {
+            SentimentalAnalysis analysis = analysisOptional.get();
+            response.put("mood", analysis.getMoodName());
+            response.put("moodmeter", analysis.getMoodmeter());
+            response.put("content", analysis.getContent());
+        } else {
+            response.put("analysisResult", "분석 데이터가 없습니다.");
+        }
+
+        return response;
+    }
+}

--- a/src/main/java/com/example/thedayoftoday/domain/entity/Diary.java
+++ b/src/main/java/com/example/thedayoftoday/domain/entity/Diary.java
@@ -36,14 +36,14 @@ public class Diary {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "analysisId_id")
-    private Sentimentalanalysis sentimentAnalysis;
+    private SentimentalAnalysis sentimentAnalysis;
 
 
     @Builder
     public Diary(String title, String content,
                  LocalDateTime createTime,
                  User user,
-                 Sentimentalanalysis sentimentAnalysis) {
+                 SentimentalAnalysis sentimentAnalysis) {
         this.title = title;
         this.content = content;
         this.createTime = createTime;

--- a/src/main/java/com/example/thedayoftoday/domain/entity/Sentimentalanalysis.java
+++ b/src/main/java/com/example/thedayoftoday/domain/entity/Sentimentalanalysis.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Sentimentalanalysis {
+public class SentimentalAnalysis {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,7 +31,7 @@ public class Sentimentalanalysis {
 
 
     @Builder
-    public Sentimentalanalysis(String moodName,
+    public SentimentalAnalysis(String moodName,
                                Moodmeter moodmeter,
                                String content,
                                Diary diary) {
@@ -40,6 +40,4 @@ public class Sentimentalanalysis {
         this.diary = diary;
         this.content = content;
         }
-
-
 }

--- a/src/main/java/com/example/thedayoftoday/domain/repository/DiaryRepository.java
+++ b/src/main/java/com/example/thedayoftoday/domain/repository/DiaryRepository.java
@@ -1,7 +1,7 @@
 package com.example.thedayoftoday.domain.repository;
 
 import com.example.thedayoftoday.domain.entity.Diary;
-import com.example.thedayoftoday.domain.entity.Sentimentalanalysis;
+import com.example.thedayoftoday.domain.entity.SentimentalAnalysis;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -13,7 +13,7 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     //특정 diary id의 감정분석 조회
     @Query("SELECT d.sentimentAnalysis FROM Diary d WHERE d.diaryId = :diaryId")
-    Optional<Sentimentalanalysis> findSentimentAnalysisByDiaryId(@Param("diaryId") Long diaryId);
+    Optional<SentimentalAnalysis> findSentimentAnalysisByDiaryId(@Param("diaryId") Long diaryId);
     // 특정 유저 ID로 모든 Diary 조회
     List<Diary> findByUser_UserId(Long userId);
 

--- a/src/main/java/com/example/thedayoftoday/domain/repository/SentimentalanalysisRepository.java
+++ b/src/main/java/com/example/thedayoftoday/domain/repository/SentimentalanalysisRepository.java
@@ -1,10 +1,10 @@
 package com.example.thedayoftoday.domain.repository;
 
-import com.example.thedayoftoday.domain.entity.Sentimentalanalysis;
+import com.example.thedayoftoday.domain.entity.SentimentalAnalysis;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface SentimentalanalysisRepository extends JpaRepository<Sentimentalanalysis, Long> {
+public interface SentimentalAnalysisRepository extends JpaRepository<SentimentalAnalysis, Long> {
 
 }

--- a/src/test/java/com/example/thedayoftoday/DiaryRepositoryTest.java
+++ b/src/test/java/com/example/thedayoftoday/DiaryRepositoryTest.java
@@ -2,7 +2,6 @@ package com.example.thedayoftoday;
 
 import com.example.thedayoftoday.domain.entity.Diary;
 import com.example.thedayoftoday.domain.entity.SentimentalAnalysis;
-import com.example.thedayoftoday.domain.entity.Sentimentalanalysis;
 import com.example.thedayoftoday.domain.entity.User;
 import com.example.thedayoftoday.domain.entity.enumType.Moodmeter;
 import com.example.thedayoftoday.domain.repository.DiaryRepository;

--- a/src/test/java/com/example/thedayoftoday/DiaryRepositoryTest.java
+++ b/src/test/java/com/example/thedayoftoday/DiaryRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.example.thedayoftoday;
 
 import com.example.thedayoftoday.domain.entity.Diary;
+import com.example.thedayoftoday.domain.entity.SentimentalAnalysis;
 import com.example.thedayoftoday.domain.entity.Sentimentalanalysis;
 import com.example.thedayoftoday.domain.entity.User;
 import com.example.thedayoftoday.domain.entity.enumType.Moodmeter;
@@ -44,7 +45,7 @@ class DiaryRepositoryTest {
 
         entityManager.persist(user);
 
-        Sentimentalanalysis analysis = Sentimentalanalysis.builder()
+        SentimentalAnalysis analysis = SentimentalAnalysis.builder()
                 .moodName("Happy")
                 .moodmeter(Moodmeter.HAPPY)
                 .content("Feeling good!")
@@ -61,7 +62,7 @@ class DiaryRepositoryTest {
         entityManager.persist(diary);
 
         // when
-        Optional<Sentimentalanalysis> result = diaryRepository.findSentimentAnalysisByDiaryId(diary.getDiaryId());
+        Optional<SentimentalAnalysis> result = diaryRepository.findSentimentAnalysisByDiaryId(diary.getDiaryId());
 
         // then
         assertThat(result).isPresent();

--- a/src/test/java/com/example/thedayoftoday/domain/CalendarServiceTest.java
+++ b/src/test/java/com/example/thedayoftoday/domain/CalendarServiceTest.java
@@ -1,0 +1,93 @@
+package com.example.thedayoftoday.domain;
+
+import com.example.thedayoftoday.domain.entity.Diary;
+import com.example.thedayoftoday.domain.entity.SentimentalAnalysis;
+import com.example.thedayoftoday.domain.repository.DiaryRepository;
+import com.example.thedayoftoday.domain.repository.SentimentalAnalysisRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CalendarServiceTest {
+
+    @Mock
+    private DiaryRepository diaryRepository;
+
+    @Mock
+    private SentimentalAnalysisRepository sentimentalAnalysisRepository;
+
+    @InjectMocks
+    private CalendarService calendarService;
+
+    private Diary testDiary;
+    private SentimentalAnalysis testAnalysis;
+
+    @BeforeEach
+    void setUp() {
+        testDiary = Diary.builder()
+                .title("테스트")
+                .content("테스트 내용")
+                .createTime(LocalDateTime.of(2025, 2, 15, 10, 0))
+                .user(null) // Mocking, so no need for actual user
+                .sentimentAnalysis(null)
+                .build();
+
+        testAnalysis = SentimentalAnalysis.builder()
+                .moodName("기쁨")
+                .content("매우 기쁨기쁨기쁨")
+                .diary(testDiary)
+                .build();
+    }
+
+    @Test
+    void testGetMonthColors() {
+        Long userId = 1L;
+        LocalDateTime startDate = LocalDateTime.of(2025, 2, 1, 0, 0);
+        LocalDateTime endDate = LocalDateTime.of(2025, 2, 28, 23, 59);
+
+        when(diaryRepository.findByUser_UserIdAndCreateTimeBetween(userId, startDate, endDate))
+                .thenReturn(Collections.singletonList(testDiary));
+
+        Map<String, Object> result = calendarService.getMonthColors(userId, startDate, endDate);
+
+        assertEquals(userId, result.get("userId"));
+        assertNotNull(result.get("colors"));
+    }
+
+    @Test
+    void testGetDiaryEntry() {
+        Long userId = 1L;
+        LocalDateTime date = LocalDateTime.of(2025, 2, 15, 0, 0);
+
+        when(diaryRepository.findByUser_UserIdAndCreateTimeBetween(anyLong(), any(), any()))
+                .thenReturn(Collections.singletonList(testDiary));
+
+        Map<String, Object> result = calendarService.getDiaryEntry(userId, date);
+
+        assertEquals(userId, result.get("userId"));
+        assertNotNull(result.get("entries"));
+    }
+
+    @Test
+    void testGetSentimentalAnalysis() {
+        Long diaryId = 1L;
+
+        when(diaryRepository.findSentimentAnalysisByDiaryId(diaryId))
+                .thenReturn(Optional.of(testAnalysis));
+
+        Map<String, Object> result = calendarService.getSentimentalAnalysis(diaryId);
+
+        assertEquals("기쁨", result.get("mood"));
+        assertEquals("매우 기쁨기쁨기쁨", result.get("content"));
+    }
+}

--- a/src/test/java/com/example/thedayoftoday/domain/CalendarServiceTest.java
+++ b/src/test/java/com/example/thedayoftoday/domain/CalendarServiceTest.java
@@ -80,14 +80,31 @@ class CalendarServiceTest {
 
     @Test
     void testGetSentimentalAnalysis() {
-        Long diaryId = 1L;
+        Long userId = 1L;
+        LocalDateTime date = LocalDateTime.of(2025, 2, 15, 0, 0);
 
-        when(diaryRepository.findSentimentAnalysisByDiaryId(diaryId))
-                .thenReturn(Optional.of(testAnalysis));
+        Diary testDiaryWithAnalysis = Diary.builder()
+                .title("행복한 하루")
+                .content("오늘은 정말 즐거운 날이었다.")
+                .createTime(date)
+                .user(null)
+                .sentimentAnalysis(testAnalysis)
+                .build();
 
-        Map<String, Object> result = calendarService.getSentimentalAnalysis(diaryId);
+        List<Diary> mockDiaries = Collections.singletonList(testDiaryWithAnalysis);
 
-        assertEquals("기쁨", result.get("mood"));
-        assertEquals("매우 기쁨기쁨기쁨", result.get("content"));
+        when(diaryRepository.findByUser_UserIdAndCreateTimeBetween(eq(userId), any(), any()))
+                .thenReturn(mockDiaries);
+
+        Map<String, Object> result = calendarService.getSentimentalAnalysis(userId, date);
+
+        assertEquals(userId, result.get("userId"));
+        assertEquals("2025-02-15", result.get("date"));
+
+        List<Map<String, Object>> analysisResults = (List<Map<String, Object>>) result.get("analysisResults");
+        assertNotNull(analysisResults);
+        assertFalse(analysisResults.isEmpty());
+        assertEquals("기쁨", analysisResults.get(0).get("mood"));
+        assertEquals("매우 기쁨기쁨기쁨", analysisResults.get(0).get("content"));
     }
 }


### PR DESCRIPTION
달력 서비스와 달력 컨트롤러를 추가했습니다.

기능
- 연,월 요청 시 해당 달의 날짜의 모든 색깔 전달
- 연,월,일 요청 시 해당 날짜의 일기 내용 전달
- 연,월,일 요청 시 해당 날짜의 분석 내용 전달