### PR TITLE
feat :  API를 이용한 음성 텍스트 변환 및 감정분석 결과 도출 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
 
 	//swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
 }
 
 sourceSets {

--- a/src/main/java/com/example/thedayoftoday/app/ChatController.java
+++ b/src/main/java/com/example/thedayoftoday/app/ChatController.java
@@ -1,0 +1,45 @@
+package com.example.thedayoftoday.app;
+
+import com.example.thedayoftoday.domain.dto.DiaryRequestDto;
+import com.example.thedayoftoday.domain.service.AiService;
+import java.io.IOException;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/chat")
+public class ChatController {
+
+    private final AiService openAiService;
+
+    public ChatController(AiService openAiService) {
+        this.openAiService = openAiService;
+    }
+
+    // 음성 파일을 받아서 텍스트로 변환
+    @PostMapping("/transcribe")
+    public String transcribeAudio(@RequestParam("file") MultipartFile file) {
+        try {
+            return openAiService.transcribeAudio(file);
+        } catch (IOException e) {
+            return "파일 오류: " + e.getMessage();
+        }
+    }
+
+    // 텍스트를 일기 형식으로 변환
+    @PostMapping("/diary")
+    public DiaryRequestDto convertToDiary(@RequestBody String text) {
+        return openAiService.convertToDiary(text);
+    }
+
+    // 텍스트 감정 분석
+    @PostMapping("/emotion")
+    public String analyzeEmotion(@RequestBody String text) {
+        return openAiService.analyzeTextEmotion(text);
+    }
+
+}

--- a/src/main/java/com/example/thedayoftoday/app/DiaryController.java
+++ b/src/main/java/com/example/thedayoftoday/app/DiaryController.java
@@ -2,6 +2,7 @@ package com.example.thedayoftoday.app;
 
 import com.example.thedayoftoday.domain.dto.DiaryRequestDto;
 import com.example.thedayoftoday.domain.dto.DiaryResponseDto;
+import com.example.thedayoftoday.domain.service.AiService;
 import com.example.thedayoftoday.domain.service.DiaryService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/example/thedayoftoday/domain/security/config/SecurityConfig.java
+++ b/src/main/java/com/example/thedayoftoday/domain/security/config/SecurityConfig.java
@@ -89,7 +89,7 @@ public class SecurityConfig {
                                 "/",
                                 "/error",
                                 "/login",
-                                "/join",
+                                "/signup",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/reissue").permitAll()

--- a/src/main/java/com/example/thedayoftoday/domain/service/AiService.java
+++ b/src/main/java/com/example/thedayoftoday/domain/service/AiService.java
@@ -1,0 +1,255 @@
+package com.example.thedayoftoday.domain.service;
+
+import com.example.thedayoftoday.domain.dto.DiaryRequestDto;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+public class AiService {
+
+    @Value("${openai.api.key}")
+    private String apiKey;
+
+    private static final String WHISPER_URL = "https://api.openai.com/v1/audio/transcriptions";
+    private final RestTemplate restTemplate = new RestTemplate();
+    private static final String GPT_URL = "https://api.openai.com/v1/chat/completions";
+    private static final long MAX_FILE_SIZE = 25 * 1024 * 1024; // 25MB 제한
+
+    //  음성 파일을 STT 변환 (Whisper API)
+    public String transcribeAudio(MultipartFile audioFile) throws IOException {
+        File tempFile = convertMultipartFileToFile(audioFile);
+
+        // MP3 파일이면 WAV로 변환
+        if (audioFile.getOriginalFilename() != null && audioFile.getOriginalFilename().endsWith(".mp3")) {
+            tempFile = convertMp3ToWav(tempFile);
+        }
+
+        // 파일이 25MB 초과면 FFmpeg로 분할
+        if (tempFile.length() > MAX_FILE_SIZE) {
+            return transcribeLargeAudio(tempFile);
+        }
+
+        return sendToWhisperApi(tempFile);
+    }
+
+    //  대용량 오디오 분할 및 STT 변환
+    private String transcribeLargeAudio(File audioFile) throws IOException {
+        List<File> splitFiles = splitAudioFileWithFFmpeg(audioFile);
+        StringBuilder fullTranscription = new StringBuilder();
+
+        for (File part : splitFiles) {
+            String partText = sendToWhisperApi(part);
+            fullTranscription.append(partText).append(" ");
+        }
+
+        return fullTranscription.toString().trim();
+    }
+
+    // Whisper API 요청 (파일 전송)
+    private String sendToWhisperApi(File audioFile) throws IOException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+        headers.setBearerAuth(apiKey);
+
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        body.add("file", new ByteArrayResource(readFileBytes(audioFile)) {
+            @Override
+            public String getFilename() {
+                return audioFile.getName();
+            }
+        });
+        body.add("model", "whisper-1");
+
+        HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                WHISPER_URL, HttpMethod.POST, requestEntity, new ParameterizedTypeReference<>() {
+                }
+        );
+
+        Map<String, Object> responseBody = response.getBody();
+        return responseBody != null ? (String) responseBody.get("text") : "OPENAI로부터 아무런 응답이 없습니다";
+    }
+
+    // MP3 → WAV 변환 (FFmpeg 사용)
+    private File convertMp3ToWav(File mp3File) throws IOException {
+        File wavFile = new File(mp3File.getParent(), mp3File.getName().replace(".mp3", ".wav"));
+
+        ProcessBuilder builder = new ProcessBuilder(
+                "ffmpeg", "-i", mp3File.getAbsolutePath(), "-ar", "16000", "-ac", "1", "-c:a", "pcm_s16le",
+                wavFile.getAbsolutePath()
+        );
+        builder.redirectErrorStream(true);
+        Process process = builder.start();
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                log.info(line);
+            }
+        }
+
+        checkProcessExitCode(process);
+
+        return wavFile;
+    }
+
+    private static void checkProcessExitCode(Process process) throws IOException {
+        try {
+            int exitCode = process.waitFor();
+            if (exitCode != 0) {
+                throw new IOException("FFmpeg로 MP3 파일을 WAV로 만드는데 실패");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt(); // 현재 스레드의 인터럽트 상태 유지
+            throw new IOException("FFmpeg process는 현재 interrupted", e);
+        }
+    }
+
+    // 오디오 파일을 FFmpeg로 25MB 이하로 분할
+    private List<File> splitAudioFileWithFFmpeg(File inputFile) throws IOException {
+        List<File> splitFiles = new ArrayList<>();
+        String outputPattern = inputFile.getParent() + "/split_%03d.wav";
+
+        ProcessBuilder builder = new ProcessBuilder(
+                "ffmpeg", "-i", inputFile.getAbsolutePath(), "-f", "segment", "-segment_time", "30",
+                "-c", "copy", outputPattern
+        );
+        builder.redirectErrorStream(true);
+        Process process = builder.start();
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                log.info("[FFmpeg] {}", line);
+            }
+        }
+
+        checkProcessExitCode(process);
+
+        File parentDir = inputFile.getParentFile();
+        File[] files = parentDir.listFiles((dir, name) -> name.startsWith("split_") && name.endsWith(".wav"));
+        if (files != null) {
+            splitFiles.addAll(List.of(files));
+        }
+        return splitFiles;
+    }
+
+    // 텍스트를 "일기 형식"으로 변환
+
+    public DiaryRequestDto convertToDiary(String text) {
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("model", "gpt-3.5-turbo");
+        requestBody.put("messages", List.of(
+                Map.of("role", "system", "content", "You are a diary-writing assistant. " +
+                        "Generate a diary entry in JSON format with the keys: 'title' and 'content'."),
+                Map.of("role", "user", "content", "다음 내용을 바탕으로 일기를 작성해줘:\n" + text)
+        ));
+
+        String response = callOpenAiApi(requestBody);
+        return parseDiaryResponse(response);
+    }
+
+    private DiaryRequestDto parseDiaryResponse(String response) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode rootNode = objectMapper.readTree(response); //response를 직렬화시켜주기위해 사용
+
+            String title = rootNode.has("title") ? rootNode.get("title").asText() : "제목 없음";
+            String content = rootNode.has("content") ? rootNode.get("content").asText() : "내용 없음";
+
+            return new DiaryRequestDto(title, content);
+        } catch (Exception e) {
+            log.error("일기 변환 중 오류 발생: {}", e.getMessage());
+            return new DiaryRequestDto("변환 오류", "일기 내용을 생성하는데 실패했습니다.");
+        }
+    }
+
+    // 텍스트 감정 분석
+    public String analyzeTextEmotion(String text) {
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("model", "gpt-3.5-turbo");
+        requestBody.put("messages", List.of(
+                Map.of("role", "system", "content", "Analyze the emotions of the given text."),
+                Map.of("role", "user", "content", "다음 텍스트의 감정을 분석해줘: " + text)
+        ));
+
+        return callOpenAiApi(requestBody);
+    }
+
+    // OpenAI API 공통 호출 메서드
+    private String callOpenAiApi(Map<String, Object> requestBody) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(apiKey);
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                GPT_URL, HttpMethod.POST, entity, new ParameterizedTypeReference<>() {
+                }
+        );
+
+        Map<String, Object> responseBody = response.getBody();
+        if (responseBody != null && responseBody.containsKey("choices")) {
+            Object choicesObj = responseBody.get("choices");
+
+            if (choicesObj instanceof List<?> choices) {
+                if (!choices.isEmpty() && choices.get(0) instanceof Map<?, ?> firstChoice) {
+                    Object messageObj = firstChoice.get("message");
+
+                    if (messageObj instanceof Map<?, ?> message) {
+                        Object contentObj = message.get("content");
+
+                        // content가 List일 경우 첫 번째 요소 가져오기 (GPT 모델이 지멋대로 바꿀 수 있어서)
+                        if (contentObj instanceof List<?> contentList && !contentList.isEmpty()) {
+                            Object firstContent = contentList.get(0);
+                            return firstContent instanceof String ? (String) firstContent : "해당 내용을 찾을수 없습니다.";
+                        }
+
+                        return contentObj instanceof String ? (String) contentObj : "해당 내용을 찾을수 없습니다.";
+                    }
+                }
+            }
+        }
+        return "응답이 없습니다.";
+    }
+
+    // MultipartFile을 File로 변환
+    private File convertMultipartFileToFile(MultipartFile file) throws IOException {
+        String fileName = Optional.ofNullable(file.getOriginalFilename()).orElse("default.tmp");
+        File convFile = new File(System.getProperty("java.io.tmpdir"), fileName);
+        try (FileOutputStream fos = new FileOutputStream(convFile)) {
+            fos.write(file.getBytes());
+        }
+        return convFile;
+    }
+
+    //파일 읽어들이기
+    private byte[] readFileBytes(File file) throws IOException {
+        return java.nio.file.Files.readAllBytes(file.toPath());
+    }
+}

--- a/src/main/java/com/example/thedayoftoday/domain/service/DiaryService.java
+++ b/src/main/java/com/example/thedayoftoday/domain/service/DiaryService.java
@@ -6,7 +6,6 @@ import com.example.thedayoftoday.domain.dto.SentimentalAnalysisResponseDto;
 import com.example.thedayoftoday.domain.entity.Diary;
 import com.example.thedayoftoday.domain.entity.User;
 import com.example.thedayoftoday.domain.repository.DiaryRepository;
-import com.example.thedayoftoday.domain.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,7 +38,6 @@ public class DiaryService {
                 .createTime(LocalDateTime.now())
                 .user(user)
                 .build();
-
 
         diaryRepository.save(addDiary);
 


### PR DESCRIPTION
# 🚀 feat : API를 이용한 음성 텍스트 변환 및 감정분석 결과 도출 기능 추가

- API를 활용하여 감정분석 결과를 도출하였습니다.



<img width="1710" alt="스크린샷 2025-03-13 오후 2 31 04" src="https://github.com/user-attachments/assets/5cec5964-e7df-4eaa-9bbc-988e00f529c5" />

해당 감정분석 외에도 음성 텍스트 변환, 일기양식으로 변환 다 확인하였습니다.
- 로그인 부분 분석 확인


DTO들이 record 타입으로 바뀐 후 정상 작동하는지 확인하였고, Access Token, Refresh Token이 있을 시에만 해당 분석 서비스를 이용가능한지 하확인하였으며, 해당 토큰이 있으면 사용이 가능하고 없을 시에 사용이 불가능한 것을 확인하였습니다.
<img width="1710" alt="스크린샷 2025-03-13 오후 2 30 52" src="https://github.com/user-attachments/assets/13498211-64d5-4ba8-a125-95dd7d771870" />



<img width="1710" alt="스크린샷 2025-03-13 오후 2 31 24" src="https://github.com/user-attachments/assets/b20774bb-bb97-4ad0-bce5-da7763291718" />



-  음성 텍스트 파일이 용량이 커질 경우 25MB 단위로 분할하도록 하였습니다.
- Java에서 MP3 처리가 안되어 FFMPEG를 이용하여 wav 파일로 변환하도록 하였습니다.
- API에서 받아온 파일을 직렬화하여 Jsonnode를 이용하여 "title", "content"로 분류하여 받아주었습니다.

# 🤔 미해결 사항

- AI 관련된 API와 Diary API를 단일책임 원칙을 지키기 위해 분류하였는데 이렇게 되면 일기 작성 시 API를 2번 호출해야 하는 문제가 발생합니다.
