### PR TITLE
Feat/#62/무드미터개발

### DIFF
--- a/src/main/java/com/example/thedayoftoday/ThedayoftodayApplication.java
+++ b/src/main/java/com/example/thedayoftoday/ThedayoftodayApplication.java
@@ -2,8 +2,10 @@ package com.example.thedayoftoday;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class ThedayoftodayApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/thedayoftoday/app/SentimentalAnalysisController.java
+++ b/src/main/java/com/example/thedayoftoday/app/SentimentalAnalysisController.java
@@ -1,6 +1,6 @@
 package com.example.thedayoftoday.app;
 
-import com.example.thedayoftoday.domain.dto.MoodMeterCategoryDto;
+import com.example.thedayoftoday.domain.dto.MoodCategoryResponse;
 import com.example.thedayoftoday.domain.dto.SentimentalAnalysisRequestDto;
 import com.example.thedayoftoday.domain.dto.SentimentalAnalysisResponseDto;
 import com.example.thedayoftoday.domain.service.SentimentalAnalysisService;
@@ -24,7 +24,7 @@ public class SentimentalAnalysisController {
     private final SentimentalAnalysisService sentimentalAnalysisService;
 
     @GetMapping("/moodmeters")
-    public List<MoodMeterCategoryDto> getMoodMeters() {
+    public List<MoodCategoryResponse> getMoodMeters() {
         return sentimentalAnalysisService.getAllMoodListResponseDto();
     }
 

--- a/src/main/java/com/example/thedayoftoday/app/SentimentalAnalysisController.java
+++ b/src/main/java/com/example/thedayoftoday/app/SentimentalAnalysisController.java
@@ -1,10 +1,16 @@
 package com.example.thedayoftoday.app;
 
 import com.example.thedayoftoday.domain.dto.MoodCategoryResponse;
+import com.example.thedayoftoday.domain.dto.MoodMeterCategoryDto;
 import com.example.thedayoftoday.domain.dto.SentimentalAnalysisRequestDto;
 import com.example.thedayoftoday.domain.dto.SentimentalAnalysisResponseDto;
+import com.example.thedayoftoday.domain.dto.UnknownMoodCategoryDto;
 import com.example.thedayoftoday.domain.service.SentimentalAnalysisService;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.util.List;
 
 import lombok.RequiredArgsConstructor;
@@ -24,6 +30,10 @@ public class SentimentalAnalysisController {
     private final SentimentalAnalysisService sentimentalAnalysisService;
 
     @GetMapping("/moodmeters")
+    @ApiResponse(
+            responseCode = "200",
+            content = @Content(array = @ArraySchema(schema = @Schema(oneOf = {MoodMeterCategoryDto.class, UnknownMoodCategoryDto.class})))
+    )
     public List<MoodCategoryResponse> getMoodMeters() {
         return sentimentalAnalysisService.getAllMoodListResponseDto();
     }

--- a/src/main/java/com/example/thedayoftoday/app/SettingController.java
+++ b/src/main/java/com/example/thedayoftoday/app/SettingController.java
@@ -1,0 +1,26 @@
+package com.example.thedayoftoday.app;
+
+import com.example.thedayoftoday.domain.dto.UserSettingDto;
+import com.example.thedayoftoday.domain.entity.User;
+import com.example.thedayoftoday.domain.repository.UserRepository;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SettingController {
+
+    private final UserRepository userRepository;
+
+    public SettingController(UserRepository userRepository) {this.userRepository = userRepository;
+    }
+
+    @GetMapping("/setting")
+    public UserSettingDto getSetting(@RequestParam Long userId) {
+        User user = userRepository.findById(userId).orElse(null);
+        if (user == null) {
+            throw new IllegalArgumentException("존재하지 않는 사용자입니다.");
+        }
+        return new UserSettingDto(user.getName(), user.getEmail(), user.getPhoneNumber());
+    }
+}

--- a/src/main/java/com/example/thedayoftoday/app/SettingController.java
+++ b/src/main/java/com/example/thedayoftoday/app/SettingController.java
@@ -3,7 +3,9 @@ package com.example.thedayoftoday.app;
 import com.example.thedayoftoday.domain.dto.UserSettingDto;
 import com.example.thedayoftoday.domain.entity.User;
 import com.example.thedayoftoday.domain.repository.UserRepository;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,7 +14,8 @@ public class SettingController {
 
     private final UserRepository userRepository;
 
-    public SettingController(UserRepository userRepository) {this.userRepository = userRepository;
+    public SettingController(UserRepository userRepository) {
+        this.userRepository = userRepository;
     }
 
     @GetMapping("/setting")
@@ -21,6 +24,17 @@ public class SettingController {
         if (user == null) {
             throw new IllegalArgumentException("존재하지 않는 사용자입니다.");
         }
-        return new UserSettingDto(user.getName(), user.getEmail(), user.getPhoneNumber());
+        return new UserSettingDto(user.getName(), user.getPassword(), user.getEmail(), user.getPhoneNumber());
+    }
+
+    @PutMapping("update-password")
+    public ResponseEntity<Void> updatePassword(@RequestParam Long userId, @RequestParam String newPassword) {
+        User user = userRepository.findById(userId).orElse(null);
+        if (user == null) {
+            throw new IllegalArgumentException("존재하지 않는 사용자입니다.");
+        }
+        user.setPassword(newPassword);
+        userRepository.save(user);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/thedayoftoday/domain/dto/MoodCategoryResponse.java
+++ b/src/main/java/com/example/thedayoftoday/domain/dto/MoodCategoryResponse.java
@@ -1,0 +1,7 @@
+package com.example.thedayoftoday.domain.dto;
+
+import java.util.List;
+
+public interface MoodCategoryResponse {
+    List<MoodDetailsDto> moods();
+}

--- a/src/main/java/com/example/thedayoftoday/domain/dto/MoodMeterCategoryDto.java
+++ b/src/main/java/com/example/thedayoftoday/domain/dto/MoodMeterCategoryDto.java
@@ -5,5 +5,5 @@ import java.util.List;
 public record MoodMeterCategoryDto(
         String degree,
         List<MoodDetailsDto> moods
-) {
+) implements MoodCategoryResponse {
 }

--- a/src/main/java/com/example/thedayoftoday/domain/dto/UnknownMoodCategoryDto.java
+++ b/src/main/java/com/example/thedayoftoday/domain/dto/UnknownMoodCategoryDto.java
@@ -1,0 +1,6 @@
+package com.example.thedayoftoday.domain.dto;
+
+import java.util.List;
+
+public record UnknownMoodCategoryDto(List<MoodDetailsDto> moods) implements MoodCategoryResponse {
+}

--- a/src/main/java/com/example/thedayoftoday/domain/dto/UserSettingDto.java
+++ b/src/main/java/com/example/thedayoftoday/domain/dto/UserSettingDto.java
@@ -1,0 +1,4 @@
+package com.example.thedayoftoday.domain.dto;
+
+public record UserSettingDto(String name, String email, String phoneNumber) {
+}

--- a/src/main/java/com/example/thedayoftoday/domain/dto/UserSettingDto.java
+++ b/src/main/java/com/example/thedayoftoday/domain/dto/UserSettingDto.java
@@ -1,4 +1,4 @@
 package com.example.thedayoftoday.domain.dto;
 
-public record UserSettingDto(String name, String email, String phoneNumber) {
+public record UserSettingDto(String name, String password, String email, String phoneNumber) {
 }

--- a/src/main/java/com/example/thedayoftoday/domain/dto/WeeklyAnalysisResponseDto.java
+++ b/src/main/java/com/example/thedayoftoday/domain/dto/WeeklyAnalysisResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.thedayoftoday.domain.dto;
 
+import com.example.thedayoftoday.domain.entity.enumType.Degree;
 import com.example.thedayoftoday.domain.entity.enumType.MoodMeter;
 
 import java.time.LocalDate;
@@ -9,7 +10,7 @@ public record   WeeklyAnalysisResponseDto(
         int month,
         int week,
         String title,
-        MoodMeter analysisMoodmeter,  // MoodMeter enum 적용
+        Degree degree,  // MoodMeter enum 적용
         String feedback,
         LocalDate startDate,  // LocalDate 적용
         LocalDate endDate,

--- a/src/main/java/com/example/thedayoftoday/domain/dto/WeeklyAnalysisResponseDto.java
+++ b/src/main/java/com/example/thedayoftoday/domain/dto/WeeklyAnalysisResponseDto.java
@@ -4,6 +4,7 @@ import com.example.thedayoftoday.domain.entity.enumType.Degree;
 import com.example.thedayoftoday.domain.entity.enumType.MoodMeter;
 
 import java.time.LocalDate;
+import java.time.temporal.WeekFields;
 
 public record   WeeklyAnalysisResponseDto(
         int year,
@@ -13,10 +14,12 @@ public record   WeeklyAnalysisResponseDto(
         Degree degree,  // MoodMeter enum 적용
         String feedback,
         LocalDate startDate,  // LocalDate 적용
-        LocalDate endDate,
-        String message
+        LocalDate endDate
 ) {
     public static WeeklyAnalysisResponseDto noData(int year, int month, int week) {
-        return new WeeklyAnalysisResponseDto(year, month, week, null, null, null, null, null, "해당 주차에 대한 분석 데이터가 없습니다.");
-    }
+        LocalDate base = LocalDate.of(year, month, 1);
+        WeekFields weekFields = WeekFields.ISO;
+        LocalDate start = base.with(weekFields.weekOfMonth(), week).with(weekFields.dayOfWeek(), 1);
+        LocalDate end = start.plusDays(6);
+        return new WeeklyAnalysisResponseDto(year, month, week, null, null, null, start, end);    }
 }

--- a/src/main/java/com/example/thedayoftoday/domain/dto/WeeklyTitleFeedbackResponseDto.java
+++ b/src/main/java/com/example/thedayoftoday/domain/dto/WeeklyTitleFeedbackResponseDto.java
@@ -1,0 +1,4 @@
+package com.example.thedayoftoday.domain.dto;
+
+public class WeeklyTitleFeedbackResponseDto {
+}

--- a/src/main/java/com/example/thedayoftoday/domain/dto/WeeklyTitleFeedbackResponseDto.java
+++ b/src/main/java/com/example/thedayoftoday/domain/dto/WeeklyTitleFeedbackResponseDto.java
@@ -1,4 +1,4 @@
 package com.example.thedayoftoday.domain.dto;
 
-public class WeeklyTitleFeedbackResponseDto {
+public record WeeklyTitleFeedbackResponseDto(String title, String feedback) {
 }

--- a/src/main/java/com/example/thedayoftoday/domain/entity/WeeklyData.java
+++ b/src/main/java/com/example/thedayoftoday/domain/entity/WeeklyData.java
@@ -1,5 +1,6 @@
 package com.example.thedayoftoday.domain.entity;
 
+import com.example.thedayoftoday.domain.entity.enumType.Degree;
 import com.example.thedayoftoday.domain.entity.enumType.MoodMeter;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -31,7 +32,7 @@ public class WeeklyData {
     private String title;
 
     @Enumerated(EnumType.STRING)
-    private MoodMeter analysisMoodmeter;
+    private Degree degree;
 
     @Lob
     private String feedback;
@@ -46,10 +47,12 @@ public class WeeklyData {
 
     @Builder
     public WeeklyData(String title,
+                      Degree degree,
                       String feedback,
                       LocalDate startDate,
                       LocalDate endDate,
                       User user) {
+        this.degree = degree;
         this.title = title;
         this.feedback = feedback;
         this.startDate = startDate;

--- a/src/main/java/com/example/thedayoftoday/domain/entity/enumType/Degree.java
+++ b/src/main/java/com/example/thedayoftoday/domain/entity/enumType/Degree.java
@@ -8,7 +8,8 @@ public enum Degree {
     BAD("나쁜"),
     COMFORT("편안한"),
     HARD("힘든"),
-    UNKNOWN("모르겠는");
+    UNKNOWN("모르겠는"),
+    NONE("미분석");
 
     private final String degreeName;
 

--- a/src/main/java/com/example/thedayoftoday/domain/entity/enumType/Degree.java
+++ b/src/main/java/com/example/thedayoftoday/domain/entity/enumType/Degree.java
@@ -4,10 +4,11 @@ import lombok.Getter;
 
 @Getter
 public enum Degree {
-
-    NEUTRAL("중립"),
-    POSITIVE("긍정"),
-    NEGATIVE("부정");
+    GOOD("좋은"),
+    BAD("나쁜"),
+    COMFORT("편안한"),
+    HARD("힘든"),
+    UNKNOWN("모르겠는");
 
     private final String degreeName;
 

--- a/src/main/java/com/example/thedayoftoday/domain/entity/enumType/Degree.java
+++ b/src/main/java/com/example/thedayoftoday/domain/entity/enumType/Degree.java
@@ -1,5 +1,8 @@
 package com.example.thedayoftoday.domain.entity.enumType;
 
+import lombok.Getter;
+
+@Getter
 public enum Degree {
 
     NEUTRAL("중립"),
@@ -12,7 +15,4 @@ public enum Degree {
         this.degreeName = degreeName;
     }
 
-    public String getDegreeName() {
-        return degreeName;
-    }
 }

--- a/src/main/java/com/example/thedayoftoday/domain/entity/enumType/Degree.java
+++ b/src/main/java/com/example/thedayoftoday/domain/entity/enumType/Degree.java
@@ -8,7 +8,7 @@ public enum Degree {
     BAD("나쁜"),
     COMFORT("편안한"),
     HARD("힘든"),
-    UNKNOWN("모르겠는"),
+    UNKNOWN(""),
     NONE("미분석");
 
     private final String degreeName;

--- a/src/main/java/com/example/thedayoftoday/domain/entity/enumType/MoodMeter.java
+++ b/src/main/java/com/example/thedayoftoday/domain/entity/enumType/MoodMeter.java
@@ -1,46 +1,64 @@
 package com.example.thedayoftoday.domain.entity.enumType;
 
 import java.util.Arrays;
-
 import lombok.Getter;
 
 @Getter
 public enum MoodMeter {
 
-    HAPPY(Degree.POSITIVE, "행복한", "#FFD700"),
-    EXCITED(Degree.POSITIVE, "신나는", "#FFA500"),
-    CONFIDENT(Degree.POSITIVE, "자신감 있는", "#00FF00"),
-    GRATEFUL(Degree.POSITIVE, "감사한", "#FFC0CB"),
-    HOPEFUL(Degree.POSITIVE, "희망찬", "#E6E6FA"),
-    INSPIRED(Degree.POSITIVE, "영감을 받은", "#FF69B4"),
-    LOVING(Degree.POSITIVE, "사랑하는", "#FF6347"),
-    DETERMINED(Degree.POSITIVE, "단호한", "#008080"),
-    ENTHUSIASTIC(Degree.POSITIVE, "열정적인", "#FF4500"),
+    ANXIOUS(Degree.BAD, "불안한", "#73272b"),
+    DISGUSTED(Degree.BAD, "불쾌한", "#772726"),
+    SCARED(Degree.BAD, "겁먹은", "#ab332d"),
+    WORRIED(Degree.BAD, "걱정하는", "#ab322e"),
+    STRESSED(Degree.BAD, "스트레스 받는", "#cb5232"),
+    ANGRY(Degree.BAD, "화난", "#d05233"),
+    NERVOUS(Degree.BAD, "초조한", "#e46238"),
+    IRRITATED(Degree.BAD, "짜증나는", "#e56239"),
+    UNCOMFORTABLE(Degree.BAD, "마음이 불편한", "#e66239"),
+    SHOCKED(Degree.BAD, "충격받은", "#e7813d"),
+    NUMB(Degree.BAD, "망연자실한", "#e4833d"),
+    RESTLESS(Degree.BAD, "안절부절못하는", "#e7813f"),
 
-    NORMAL(Degree.NEUTRAL, "평범한", "#808080"),
-    CALM(Degree.NEUTRAL, "차분한", "#A9A9A9"),
-    CONTENT(Degree.NEUTRAL, "만족한", "#D3D3D3"),
-    FOCUSED(Degree.NEUTRAL, "집중한", "#4682B4"),
-    SHY(Degree.NEUTRAL, "수줍은", "#B0C4DE"),
-    CURIOUS(Degree.NEUTRAL, "호기심 많은", "#ADD8E6"),
-    RELIEVED(Degree.NEUTRAL, "안도한", "#F5F5DC"),
+    SURPRISED(Degree.GOOD, "놀란", "#f5e87a"),
+    SATISFIED(Degree.GOOD, "만족스러운", "#f5e978"),
+    POSITIVE(Degree.GOOD, "긍정적인", "#f3d75c"),
+    FOCUSED(Degree.GOOD, "집중하는", "#f5d75b"),
+    GLAD(Degree.GOOD, "기쁜", "#f6d759"),
+    JOYFUL(Degree.GOOD, "흥겨운", "#f3cd5a"),
+    MOTIVATED(Degree.GOOD, "동기부여된", "#f2cd57"),
+    EXCITED(Degree.GOOD, "흥분한", "#f2ce59"),
+    HAPPY(Degree.GOOD, "행복한", "#f1cd59"),
+    INSPIRED(Degree.GOOD, "영감을 받은", "#eebd55"),
+    FUN(Degree.GOOD, "재미있는", "#edbd57"),
+    THRILLED(Degree.GOOD, "짜릿한", "#edb149"),
 
-    SAD(Degree.NEGATIVE, "슬픈", "#000080"),
-    ANGRY(Degree.NEGATIVE, "화난", "#8B0000"),
-    LONELY(Degree.NEGATIVE, "외로운", "#4B0082"),
-    DISAPPOINTED(Degree.NEGATIVE, "실망한", "#696969"),
-    GUILTY(Degree.NEGATIVE, "죄책감이 드는", "#DC143C"),
-    FRUSTRATED(Degree.NEGATIVE, "좌절한", "#A52A2A"),
-    TIRED(Degree.NEGATIVE, "피곤한", "#708090"),
-    STRESSED(Degree.NEGATIVE, "스트레스받은", "#2F4F4F"),
-    AFRAID(Degree.NEGATIVE, "두려운", "#800000"),
-    ASHAMED(Degree.NEGATIVE, "부끄러운", "#FF0000"),
-    OVERWHELMED(Degree.NEGATIVE, "압도된", "#8B4513"),
-    JEALOUS(Degree.NEGATIVE, "질투하는", "#556B2F"),
-    HOPELESS(Degree.NEGATIVE, "절망적인", "#8B0000"),
-    MELANCHOLIC(Degree.NEGATIVE, "우울한", "#483D8B"),
-    REGRETFUL(Degree.NEGATIVE, "후회하는", "#5F9EA0"),
-    BITTER(Degree.NEGATIVE, "씁쓸한", "#696969");
+    DISGUSTED2(Degree.HARD, "역겨운", "#201f77"),
+    ISOLATED(Degree.HARD, "소외된", "#201f78"),
+    DESPERATE(Degree.HARD, "절망한", "#1f1e77"),
+    MISERABLE(Degree.HARD, "비참한", "#212291"),
+    DEPRESSED(Degree.HARD, "우울한", "#1f2391"),
+    DISCOURAGED(Degree.HARD, "낙담한", "#2c46b4"),
+    LONELY(Degree.HARD, "쓸쓸한", "#2d47b5"),
+    UNMOTIVATED(Degree.HARD, "의욕없는", "#3c71d8"),
+    SAD(Degree.HARD, "슬픈", "#3c72d6"),
+    BORED(Degree.HARD, "지루한", "#52a1ea"),
+    TIRED(Degree.HARD, "피곤한", "#52a2e8"),
+    EXHAUSTED(Degree.HARD, "지친", "#52a3e6"),
+
+    PEACEFUL(Degree.COMFORT, "평온한", "#a1d34d"),
+    RELAXED(Degree.COMFORT, "여유로운", "#a6d44e"),
+    DROWSY(Degree.COMFORT, "나른한", "#a7d44b"),
+    CALM(Degree.COMFORT, "차분한", "#8dbf44"),
+    THOUGHTFUL(Degree.COMFORT, "생각에 잠긴", "#8cbe42"),
+    PROUD(Degree.COMFORT, "흐뭇한", "#8cbf46"),
+    COMFORTABLE(Degree.COMFORT, "편안한", "#79af40"),
+    SERENE(Degree.COMFORT, "평화로운", "#79ae3d"),
+    GRATEFUL(Degree.COMFORT, "감사하는", "#51a43b"),
+    BLESSED(Degree.COMFORT, "축복받은", "#51a23c"),
+    COZY(Degree.COMFORT, "안락한", "#4fa43b"),
+    TOUCHED(Degree.COMFORT, "감동적인", "#468c33"),
+    
+    UNKNOWN(Degree.UNKNOWN, "모르겠는", "#ffffff");
 
     private final Degree degree;
     private final String moodName;
@@ -61,7 +79,7 @@ public enum MoodMeter {
 
     public static MoodMeter fromColor(String color) {
         return Arrays.stream(values())
-                .filter(mood -> mood.color.equals(color))
+                .filter(mood -> mood.color.equalsIgnoreCase(color))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("해당 색상을 찾을 수 없습니다: " + color));
     }

--- a/src/main/java/com/example/thedayoftoday/domain/entity/enumType/MoodMeter.java
+++ b/src/main/java/com/example/thedayoftoday/domain/entity/enumType/MoodMeter.java
@@ -57,7 +57,7 @@ public enum MoodMeter {
     BLESSED(Degree.COMFORT, "축복받은", "#51a23c"),
     COZY(Degree.COMFORT, "안락한", "#4fa43b"),
     TOUCHED(Degree.COMFORT, "감동적인", "#468c33"),
-    
+
     UNKNOWN(Degree.UNKNOWN, "모르겠는", "#ffffff");
 
     private final Degree degree;

--- a/src/main/java/com/example/thedayoftoday/domain/scheduler/WeeklySummaryScheduler.java
+++ b/src/main/java/com/example/thedayoftoday/domain/scheduler/WeeklySummaryScheduler.java
@@ -1,0 +1,4 @@
+package com.example.thedayoftoday.domain.scheduler;
+
+public class WeeklySummaryScheduler {
+}

--- a/src/main/java/com/example/thedayoftoday/domain/scheduler/WeeklySummaryScheduler.java
+++ b/src/main/java/com/example/thedayoftoday/domain/scheduler/WeeklySummaryScheduler.java
@@ -1,4 +1,66 @@
 package com.example.thedayoftoday.domain.scheduler;
 
+import com.example.thedayoftoday.domain.dto.WeeklyTitleFeedbackResponseDto;
+import com.example.thedayoftoday.domain.entity.Diary;
+import com.example.thedayoftoday.domain.entity.User;
+import com.example.thedayoftoday.domain.entity.WeeklyData;
+import com.example.thedayoftoday.domain.entity.enumType.Degree;
+import com.example.thedayoftoday.domain.repository.UserRepository;
+import com.example.thedayoftoday.domain.repository.WeeklyDataRepository;
+import com.example.thedayoftoday.domain.service.AiService;
+import com.example.thedayoftoday.domain.service.WeeklyAnalysisService;
+import java.time.LocalDate;
+import java.time.temporal.WeekFields;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class WeeklySummaryScheduler {
+
+    private final WeeklyAnalysisService weeklyAnalysisService;
+    private final AiService aiService;
+    private final UserRepository userRepository;
+    private final WeeklyDataRepository weeklyDataRepository;
+
+    @Scheduled(cron = "59 59 23 * * SUN", zone = "Asia/Seoul")
+    public void summarizeWeeklyDiaries() {
+        List<User> allUsers = userRepository.findAll();
+
+        for (User user : allUsers) {
+            LocalDate now = LocalDate.now();
+            WeekFields weekFields = WeekFields.ISO;
+
+            int year = now.getYear();
+            int month = now.getMonthValue();
+            int week = now.get(weekFields.weekOfMonth());
+
+            List<Diary> diaries = weeklyAnalysisService.getWeeklyDiary(user.getUserId(), year, month, week);
+            String combined = weeklyAnalysisService.combineWeeklyDiary(diaries);
+
+            if (combined.isBlank()) continue;
+
+            WeeklyTitleFeedbackResponseDto feedbackDto = aiService.analyzeWeeklyDiaryWithTitle(combined);
+            Degree degree = aiService.analyzeDegree(combined);
+
+            LocalDate baseDate = now.withDayOfMonth(1);
+            LocalDate startDate = baseDate
+                    .with(weekFields.weekOfMonth(), week)
+                    .with(weekFields.dayOfWeek(), 1);
+            LocalDate endDate = startDate.plusDays(6);
+
+            WeeklyData weeklyData = WeeklyData.builder()
+                    .user(user)
+                    .title(feedbackDto.title())
+                    .feedback(feedbackDto.feedback())
+                    .degree(degree)
+                    .startDate(startDate)
+                    .endDate(endDate)
+                    .build();
+
+            weeklyDataRepository.save(weeklyData);
+        }
+    }
 }

--- a/src/main/java/com/example/thedayoftoday/domain/service/AiService.java
+++ b/src/main/java/com/example/thedayoftoday/domain/service/AiService.java
@@ -1,8 +1,12 @@
 package com.example.thedayoftoday.domain.service;
 
 import com.example.thedayoftoday.domain.dto.DiaryBasicResponseDto;
+import com.example.thedayoftoday.domain.dto.WeeklyAnalysisResponseDto;
+import com.example.thedayoftoday.domain.dto.WeeklyTitleFeedbackResponseDto;
 import com.example.thedayoftoday.domain.entity.Diary;
 import com.example.thedayoftoday.domain.entity.DiaryMood;
+import com.example.thedayoftoday.domain.entity.WeeklyData;
+import com.example.thedayoftoday.domain.entity.enumType.Degree;
 import com.example.thedayoftoday.domain.entity.enumType.MoodMeter;
 import com.example.thedayoftoday.domain.repository.DiaryRepository;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -315,7 +319,80 @@ public class AiService {
         ));
         return callOpenAiApi(requestBody);
     }
+    public WeeklyTitleFeedbackResponseDto analyzeWeeklyDiaryWithTitle(String combinedWeeklyDiary) {
+        if (combinedWeeklyDiary == null || combinedWeeklyDiary.isBlank()) {
+            return new WeeklyTitleFeedbackResponseDto("무기록", "해당 주간에는 작성된 일기가 없습니다.");
+        }
 
+        String prompt = """
+    아래는 사용자의 일주일간 일기 모음입니다.
+    각 일기에는 사용자가 선택한 감정이 포함되어 있습니다.
+
+    이 일기를 분석하여 감정의 흐름, 성향, 감정 변화의 원인 등을 바탕으로
+    아래 형식처럼 작성해주세요:
+
+    제목: 짧고 상징적인 한 줄 제목
+    피드백: 감정 흐름에 대한 공감 가는 피드백, 최소 6문장 이상
+
+    일기 모음:
+    %s
+    """.formatted(combinedWeeklyDiary);
+
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("model", "gpt-3.5-turbo");
+        requestBody.put("messages", List.of(
+                Map.of("role", "system", "content", "너는 공감과 감정 분석에 능숙한 피드백 작성 도우미야."),
+                Map.of("role", "user", "content", prompt)
+        ));
+
+        String response = callOpenAiApi(requestBody);
+
+        try {
+            String[] parts = response.split("피드백:", 2);
+            String title = parts[0].replace("제목:", "").trim();
+            String feedback = parts.length > 1 ? parts[1].trim() : "피드백 없음";
+            return new WeeklyTitleFeedbackResponseDto(title, feedback);
+        } catch (Exception e) {
+            log.error("응답 파싱 실패: {}", e.getMessage());
+            return new WeeklyTitleFeedbackResponseDto("분석 실패", "GPT 응답을 이해할 수 없습니다.");
+        }
+    }
+
+    public Degree analyzeDegree(String combinedWeeklyDiary) {
+        if (combinedWeeklyDiary == null || combinedWeeklyDiary.isBlank()) {
+            return Degree.NEUTRAL; // 기본값 처리
+        }
+
+        String prompt = """
+        다음은 사용자의 일주일간 일기 모음입니다.
+
+        전체 감정 흐름을 종합해 다음 중 하나로 판단해주세요:
+        - 긍정
+        - 부정
+        - 중립
+
+        반드시 위 단어 중 하나만 한국어로 대답해주세요.
+
+        일기 모음:
+        %s
+        """.formatted(combinedWeeklyDiary);
+
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("model", "gpt-3.5-turbo");
+        requestBody.put("messages", List.of(
+                Map.of("role", "system", "content", "You are an emotional analyzer. Return only one word: 긍정, 부정, 중립."),
+                Map.of("role", "user", "content", prompt)
+        ));
+
+        String response = callOpenAiApi(requestBody).trim();
+
+        return switch (response) {
+            case "긍정" -> Degree.POSITIVE;
+            case "부정" -> Degree.NEGATIVE;
+            case "중립" -> Degree.NEUTRAL;
+            default -> Degree.NEUTRAL; // 잘못된 응답 처리
+        };
+    }
     //파일 읽어들이기
     private byte[] readFileBytes(File file) throws IOException {
         return java.nio.file.Files.readAllBytes(file.toPath());

--- a/src/main/java/com/example/thedayoftoday/domain/service/SentimentalAnalysisService.java
+++ b/src/main/java/com/example/thedayoftoday/domain/service/SentimentalAnalysisService.java
@@ -7,7 +7,6 @@ import com.example.thedayoftoday.domain.dto.MoodDetailsDto;
 import com.example.thedayoftoday.domain.dto.MoodMeterCategoryDto;
 import com.example.thedayoftoday.domain.dto.SentimentalAnalysisRequestDto;
 import com.example.thedayoftoday.domain.dto.SentimentalAnalysisResponseDto;
-import com.example.thedayoftoday.domain.dto.UnknownMoodCategoryDto;
 import com.example.thedayoftoday.domain.entity.Diary;
 import com.example.thedayoftoday.domain.entity.DiaryMood;
 import com.example.thedayoftoday.domain.entity.enumType.Degree;
@@ -60,27 +59,6 @@ public class SentimentalAnalysisService {
         return new SentimentalAnalysisResponseDto(moodName, moodColor, contentAnalysis);
     }
 
-    //해당 다이어리 id에 감정분석 결과 저장해주는거임!! ->moodName(한글), content 던져주면 이에 맞게 감정분석 db, 연결되어있는 일기에도 저장
-//    public SentimentalAnalysisResponseDto addAnalysis(SentimentalAnalysisRequestDto sentimentalAnalysisRequestDto,
-//                                                      Long diaryId) {
-//        Diary diary = diaryRepository.findById(diaryId)
-//                .orElseThrow(() -> new IllegalArgumentException("해당 일기가 없습니다"));
-//
-//        SentimentalAnalysis sentimentalAnalysis = SentimentalAnalysis.builder()
-//                .analysisMoodName(sentimentalAnalysisRequestDto.analysisMoodName())
-//                .analysisMoodColor(sentimentalAnalysisRequestDto.analysisMoodColor())
-//                .analysisContent(sentimentalAnalysisRequestDto.analysisContent())
-//                .diary(diary).build();
-//
-//        sentimentalAnalysisRepository.save(sentimentalAnalysis);
-//        diary.addSentimentAnalysis(sentimentalAnalysis);
-//
-//        return new SentimentalAnalysisResponseDto(
-//                sentimentalAnalysis.getAnalysisMoodName(),
-//                sentimentalAnalysis.getAnalysisMoodColor(),
-//                sentimentalAnalysis.getAnalysisContent()
-//        );
-//    }
     public SentimentalAnalysisResponseDto addAnalysis(SentimentalAnalysisRequestDto sentimentalAnalysisRequestDto, Long diaryId) {
         Diary diary = diaryRepository.findById(diaryId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 일기가 없습니다"));
@@ -169,7 +147,6 @@ public class SentimentalAnalysisService {
 
     public List<MoodCategoryResponse> getAllMoodListResponseDto() {
         Map<Degree, List<MoodDetailsDto>> moodGroup = new LinkedHashMap<>();
-        List<MoodDetailsDto> unknownList = new ArrayList<>();
 
         for (Degree degree : Degree.values()) {
             // "미분석"은 건너뜀
@@ -179,36 +156,22 @@ public class SentimentalAnalysisService {
 
         for (MoodMeter mood : MoodMeter.values()) {
             Degree degree = mood.getDegree();
-
             if (degree == null || degree == Degree.NONE) {
-                // "미분석" 또는 Degree 자체가 null이면 무시
                 continue;
             }
-
-            if (degree == Degree.UNKNOWN) {
-                unknownList.add(new MoodDetailsDto(mood.getMoodName(), mood.getColor()));
-            } else {
-                moodGroup.get(degree).add(new MoodDetailsDto(mood.getMoodName(), mood.getColor()));
-            }
+            MoodDetailsDto dto = new MoodDetailsDto(mood.getMoodName(),mood.getColor());
+            moodGroup.get(degree).add(dto);
         }
 
-        return getMoodCategoryResponses(unknownList, moodGroup);
-    }
-
-    private static List<MoodCategoryResponse> getMoodCategoryResponses(List<MoodDetailsDto> unknownList,
-                                                                       Map<Degree, List<MoodDetailsDto>> moodGroup) {
         List<MoodCategoryResponse> moodCategories = new ArrayList<>();
 
-        // "모르겠는"은 따로 UnknownMoodCategoryDto로 출력
-        if (!unknownList.isEmpty()) {
-            moodCategories.add(new UnknownMoodCategoryDto(unknownList));
+        for (Map.Entry<Degree, List<MoodDetailsDto>> entry : moodGroup.entrySet()) {
+            moodCategories.add(
+                    new MoodMeterCategoryDto(entry.getKey().getDegreeName(), entry.getValue())
+            );
         }
 
-        for (Map.Entry<Degree, List<MoodDetailsDto>> entry : moodGroup.entrySet()) {
-            // "모르겠는" 제외 (이미 위에서 처리)
-            if (entry.getKey() == Degree.UNKNOWN) continue;
-            moodCategories.add(new MoodMeterCategoryDto(entry.getKey().getDegreeName(), entry.getValue()));
-        }
         return moodCategories;
     }
+
 }

--- a/src/main/java/com/example/thedayoftoday/domain/service/SentimentalAnalysisService.java
+++ b/src/main/java/com/example/thedayoftoday/domain/service/SentimentalAnalysisService.java
@@ -2,10 +2,12 @@ package com.example.thedayoftoday.domain.service;
 
 import static com.example.thedayoftoday.domain.entity.enumType.MoodMeter.fromMoodName;
 
+import com.example.thedayoftoday.domain.dto.MoodCategoryResponse;
 import com.example.thedayoftoday.domain.dto.MoodDetailsDto;
 import com.example.thedayoftoday.domain.dto.MoodMeterCategoryDto;
 import com.example.thedayoftoday.domain.dto.SentimentalAnalysisRequestDto;
 import com.example.thedayoftoday.domain.dto.SentimentalAnalysisResponseDto;
+import com.example.thedayoftoday.domain.dto.UnknownMoodCategoryDto;
 import com.example.thedayoftoday.domain.entity.Diary;
 import com.example.thedayoftoday.domain.entity.DiaryMood;
 import com.example.thedayoftoday.domain.entity.enumType.Degree;
@@ -165,21 +167,32 @@ public class SentimentalAnalysisService {
         }
     }
 
-    public List<MoodMeterCategoryDto> getAllMoodListResponseDto() {
+    public List<MoodCategoryResponse> getAllMoodListResponseDto() {
         Map<Degree, List<MoodDetailsDto>> moodGroup = new LinkedHashMap<>();
+        List<MoodDetailsDto> unknownList = new ArrayList<>();
 
         for (Degree value : Degree.values()) {
             moodGroup.put(value, new ArrayList<>());
         }
 
         for (MoodMeter mood : MoodMeter.values()) {
-            moodGroup.get(mood.getDegree()).add(new MoodDetailsDto(mood.getMoodName(), mood.getColor()));
+            if (mood.getDegree() == null) {
+                unknownList.add(new MoodDetailsDto(mood.getMoodName(), mood.getColor()));
+            } else {
+                moodGroup.get(mood.getDegree()).add(new MoodDetailsDto(mood.getMoodName(), mood.getColor()));
+            }
         }
 
-        List<MoodMeterCategoryDto> moodCategories = new ArrayList<>();
+        List<MoodCategoryResponse> moodCategories = new ArrayList<>();
+
         for (Map.Entry<Degree, List<MoodDetailsDto>> entry : moodGroup.entrySet()) {
             moodCategories.add(new MoodMeterCategoryDto(entry.getKey().getDegreeName(), entry.getValue()));
         }
+
+        if (!unknownList.isEmpty()) {
+            moodCategories.add(new UnknownMoodCategoryDto(unknownList));
+        }
+
         return moodCategories;
     }
 }

--- a/src/main/java/com/example/thedayoftoday/domain/service/WeeklyAnalysisService.java
+++ b/src/main/java/com/example/thedayoftoday/domain/service/WeeklyAnalysisService.java
@@ -37,7 +37,7 @@ public class WeeklyAnalysisService {
                 ? new WeeklyAnalysisResponseDto(
                 year, month, week,
                 targetWeekData.getTitle(),
-                targetWeekData.getAnalysisMoodmeter(),
+                targetWeekData.getDegree(),
                 targetWeekData.getFeedback(),
                 targetWeekData.getStartDate(),
                 targetWeekData.getEndDate(),
@@ -57,20 +57,22 @@ public class WeeklyAnalysisService {
 
     public List<Diary> getWeeklyDiary(long userId, int year, int month, int week) {
 
-        LocalDate firstDayOfMonth = LocalDate.of(year, month, 1);
-        WeekFields weekFields = WeekFields.ISO;
+        WeekFields weekFields = WeekFields.ISO; //월요일 기준으로 잡음
 
-        LocalDate startOfWeek = firstDayOfMonth
+        LocalDate baseDate = LocalDate.of(year, month, 1);
+
+        LocalDate startOfWeek = baseDate
                 .with(weekFields.weekOfMonth(), week)
-                .with(weekFields.dayOfWeek(), 1); //월요일인거 알려줌
+                .with(weekFields.dayOfWeek(), 1); // ISO 기준: 1은 월요일
 
-        LocalDate endOfWeek = startOfWeek.with(weekFields.dayOfWeek(), 7); //일요일
+        LocalDate endOfWeek = startOfWeek.plusDays(6);
 
         LocalDateTime startDateTime = startOfWeek.atStartOfDay();
         LocalDateTime endDateTime = endOfWeek.atTime(LocalTime.MAX);
 
         return diaryRepository.findByUser_UserIdAndCreateTimeBetween(userId, startDateTime, endDateTime);
     }
+    //만약 2.1(수) 이렇게 되어있으면 1월 마지막주, 2월 첫째주 다 들어감
 
     public String combineWeeklyDiary(List<Diary> diaries) {
         return diaries.stream()
@@ -80,5 +82,5 @@ public class WeeklyAnalysisService {
                 })
                 .collect(Collectors.joining("\n\n"));
     }
-    
+
 }

--- a/src/main/java/com/example/thedayoftoday/domain/service/WeeklyAnalysisService.java
+++ b/src/main/java/com/example/thedayoftoday/domain/service/WeeklyAnalysisService.java
@@ -40,8 +40,7 @@ public class WeeklyAnalysisService {
                 targetWeekData.getDegree(),
                 targetWeekData.getFeedback(),
                 targetWeekData.getStartDate(),
-                targetWeekData.getEndDate(),
-                null)
+                targetWeekData.getEndDate())
                 : WeeklyAnalysisResponseDto.noData(year, month, week);
     }
 

--- a/src/main/java/com/example/thedayoftoday/domain/service/WeeklyAnalysisService.java
+++ b/src/main/java/com/example/thedayoftoday/domain/service/WeeklyAnalysisService.java
@@ -1,19 +1,27 @@
 package com.example.thedayoftoday.domain.service;
 
 import com.example.thedayoftoday.domain.dto.WeeklyAnalysisResponseDto;
+import com.example.thedayoftoday.domain.entity.Diary;
 import com.example.thedayoftoday.domain.entity.WeeklyData;
+import com.example.thedayoftoday.domain.repository.DiaryRepository;
 import com.example.thedayoftoday.domain.repository.WeeklyDataRepository;
-import org.springframework.stereotype.Service;
-
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.WeekFields;
 import java.util.Calendar;
 import java.util.List;
+import org.springframework.stereotype.Service;
 
 @Service
 public class WeeklyAnalysisService {
-    private final WeeklyDataRepository weeklyDataRepository;
 
-    public WeeklyAnalysisService(WeeklyDataRepository weeklyDataRepository) {
+    private final WeeklyDataRepository weeklyDataRepository;
+    private final DiaryRepository diaryRepository;
+
+    public WeeklyAnalysisService(WeeklyDataRepository weeklyDataRepository, DiaryRepository diaryRepository) {
         this.weeklyDataRepository = weeklyDataRepository;
+        this.diaryRepository = diaryRepository;
     }
 
     public WeeklyAnalysisResponseDto getWeeklyAnalysis(int year, int month, int week) {
@@ -45,4 +53,22 @@ public class WeeklyAnalysisService {
 
         return dataYear == year && dataMonth == month && dataWeek == week;
     }
+
+    public List<Diary> getWeeklyData(long userId, int year, int month, int week) {
+
+        LocalDate firstDayOfMonth = LocalDate.of(year, month, 1);
+        WeekFields weekFields = WeekFields.ISO;
+
+        LocalDate startOfWeek = firstDayOfMonth
+                .with(weekFields.weekOfMonth(), week)
+                .with(weekFields.dayOfWeek(), 1); //월요일인거 알려줌
+
+        LocalDate endOfWeek = startOfWeek.with(weekFields.dayOfWeek(), 7); //일요일
+
+        LocalDateTime startDateTime = startOfWeek.atStartOfDay();
+        LocalDateTime endDateTime = endOfWeek.atTime(LocalTime.MAX);
+
+        return diaryRepository.findByUser_UserIdAndCreateTimeBetween(userId, startDateTime, endDateTime);
+    }
+
 }

--- a/src/main/java/com/example/thedayoftoday/domain/service/WeeklyAnalysisService.java
+++ b/src/main/java/com/example/thedayoftoday/domain/service/WeeklyAnalysisService.java
@@ -11,6 +11,7 @@ import java.time.LocalTime;
 import java.time.temporal.WeekFields;
 import java.util.Calendar;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -54,7 +55,7 @@ public class WeeklyAnalysisService {
         return dataYear == year && dataMonth == month && dataWeek == week;
     }
 
-    public List<Diary> getWeeklyData(long userId, int year, int month, int week) {
+    public List<Diary> getWeeklyDiary(long userId, int year, int month, int week) {
 
         LocalDate firstDayOfMonth = LocalDate.of(year, month, 1);
         WeekFields weekFields = WeekFields.ISO;
@@ -71,4 +72,11 @@ public class WeeklyAnalysisService {
         return diaryRepository.findByUser_UserIdAndCreateTimeBetween(userId, startDateTime, endDateTime);
     }
 
+    public String combineWeeklyDiary(List<Diary> diaries)
+    {
+        return diaries.stream()
+                .map(Diary::getContent)
+                .collect(Collectors.joining("\n"));
+    }
+    
 }

--- a/src/main/java/com/example/thedayoftoday/domain/service/WeeklyAnalysisService.java
+++ b/src/main/java/com/example/thedayoftoday/domain/service/WeeklyAnalysisService.java
@@ -72,11 +72,13 @@ public class WeeklyAnalysisService {
         return diaryRepository.findByUser_UserIdAndCreateTimeBetween(userId, startDateTime, endDateTime);
     }
 
-    public String combineWeeklyDiary(List<Diary> diaries)
-    {
+    public String combineWeeklyDiary(List<Diary> diaries) {
         return diaries.stream()
-                .map(Diary::getContent)
-                .collect(Collectors.joining("\n"));
+                .map(diary -> {
+                    String moodName = diary.getDiaryMood() != null ? diary.getDiaryMood().getMoodName() : "저장된 감정 없음";
+                    return "[기분: " + moodName + "]\n" + diary.getContent();
+                })
+                .collect(Collectors.joining("\n\n"));
     }
     
 }

--- a/src/main/java/com/example/thedayoftoday/domain/swagger/Swagger.java
+++ b/src/main/java/com/example/thedayoftoday/domain/swagger/Swagger.java
@@ -2,8 +2,11 @@ package com.example.thedayoftoday.domain.swagger;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 public class Swagger {
@@ -14,6 +17,10 @@ public class Swagger {
                 .info(new Info()
                         .title("The Day of Today API")
                         .version("1.0")
-                        .description("The Day of Today 프로젝트의 API 명세서입니다."));
+                        .description("The Day of Today 프로젝트의 API 명세서입니다."))
+                .servers(List.of(
+                        new Server().url("https://thedayoftoday.kro.kr").description("배포 서버"),
+                        new Server().url("http://localhost:8080").description("로컬 서버")
+                ));
     }
 }

--- a/src/test/java/com/example/thedayoftoday/domain/service/WeeklySummarySchedulerTest.java
+++ b/src/test/java/com/example/thedayoftoday/domain/service/WeeklySummarySchedulerTest.java
@@ -1,4 +1,0 @@
-package com.example.thedayoftoday.domain.service;
-
-public class WeeklySummarySchedulerTest {
-}

--- a/src/test/java/com/example/thedayoftoday/domain/service/WeeklySummarySchedulerTest.java
+++ b/src/test/java/com/example/thedayoftoday/domain/service/WeeklySummarySchedulerTest.java
@@ -1,0 +1,4 @@
+package com.example.thedayoftoday.domain.service;
+
+public class WeeklySummarySchedulerTest {
+}


### PR DESCRIPTION
# 🚀 무드미터 개발

- 기존의 무드미터를 개선하였습니다.
- Front 요구에 따라서 UnKnown 감정은 Degree 설정을 제외하여 Controller에서 출력하도록 하였습니다.(스웨거에선 잘 나오는 것 같은데 CORS 설정때문에 로컬에선 안돌아가서 확인 필요할듯)
- GPT 프롬포트를 요구사항에 맞게 수정하였습니다.
- DiaryMood 쪽에서 리팩토링이 필요하긴 할 것 같더라고요.. 같이 고민해봐야 할 듯 (존재 유무와 관련하여)
- 미분석된 내용에 대해서는 Degree엔 미분석으로 지정을해주었는데, DiryMood의 moodname, moodcolor은 그냥 널값입니다. (degree='미분석'과 같이 지정해준것이 아님.) 


## Swagger에서의 무드미터 출력 화면
<img width="809" alt="image" src="https://github.com/user-attachments/assets/bc09347d-2747-4b71-9ada-cababbd6e727" />



- 03.31 Postman으로 잘못 나오는 문제 해결하였습니다.
<img width="1700" alt="image" src="https://github.com/user-attachments/assets/344a535d-6d1a-4a95-9431-73eabb5cd9b8" />

